### PR TITLE
demo1 -> demo2 single commit

### DIFF
--- a/open-ended-capstone/Dockerfile
+++ b/open-ended-capstone/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.8-slim
 RUN pip install psycopg2-binary==2.8.6
+RUN pip install mysql-connector-python==8.0.23
 
 COPY RetailDW/* RetailDW/
 

--- a/open-ended-capstone/README.md
+++ b/open-ended-capstone/README.md
@@ -1,25 +1,60 @@
 ##  RetailDW Module
 
-###  This initial version uses psycopg2 to load and update the Product table of the proposed Postgres ETL source system.  Initial load is of 5000 records and which is followed by five incremental loads, each with 200 inserts and 50 updates.  It may be run repeatedly.
+###  A simulated data warehouse in the retail domain.  Add records to a product table on a postgres source system and extract them to a MySQL target system.
 
-###  Issue the following commands from the open-ended-capstone directory to build and run:
+### Prerequisites: docker, docker-compose
+
+###  Issue the following commands from the open-ended-capstone directory to start the databases, build and run:
 
 ```
-docker run --name postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres
+docker-compose up -d
 docker build -t retail_dw .
-docker run retail_dw
-```
-###   Expected output:
-
-```
->>> 6000 inserts and 250 updates processed.
+docker run -t retail_dw [demo1/demo2]
 ```
 
+### Demo 1 
+Initial load of 5000 records followed by five incremental loads, each with 200 inserts and 50 updates.  The demo may be run repeatedly.
+
+###   Expected output on clean system :
+
+```
+6000 inserts and 250 updates processed.
+```
+
+### Demo 2 
+Initial load of 5000 records followed by five incremental loads, each with 200 inserts and 50 updates.  Following each of the incremental loads, extract data from the source system and apply it to the target system. The demo may be run repeatedly.
+
+###   Expected output on clean system :
+
+```
+5000 inserts and 0 updates processed at source: 2021-03-31 01:44:15.664063.
+200 inserts and 50 updates processed at source: 2021-03-31 01:44:19.262280.
+5200 inserts and 0 updates processed at target: From: 1980-01-01 00:00:00 To: 2021-03-31 01:44:19.262280 
+200 inserts and 50 updates processed at source: 2021-03-31 01:44:24.846703.
+200 inserts and 50 updates processed at target: From: 2021-03-31 01:44:19.262280 To: 2021-03-31 01:44:24.846703 
+200 inserts and 50 updates processed at source: 2021-03-31 01:44:28.009200.
+200 inserts and 50 updates processed at target: From: 2021-03-31 01:44:24.846703 To: 2021-03-31 01:44:28.009200 
+200 inserts and 50 updates processed at source: 2021-03-31 01:44:31.171240.
+200 inserts and 50 updates processed at target: From: 2021-03-31 01:44:28.009200 To: 2021-03-31 01:44:31.171240 
+200 inserts and 50 updates processed at source: 2021-03-31 01:44:34.388203.
+200 inserts and 50 updates processed at target: From: 2021-03-31 01:44:31.171240 To: 2021-03-31 01:44:34.388203 
+6000 inserts and 250 updates processed at source.
+6000 inserts and 200 updates processed at target.
+
+```
 ### To inspect the product table from the Postgres CLI:
 ```
-docker run --rm -it postgres psql -h 172.17.0.1 -U postgres
+docker run --rm -it postgres psql -h 172.17.0.1 -d retaildw -U user1
 
-Enter postgres as password
+Enter user1 as password
 ``` 
 
-#### Note: This program depends on the docker host being at address 172.17.0.1
+### To inspect the product table from the MySQL CLI:
+```
+docker run -it mysql:8.0.23 mysql -h 172.17.0.1 -D retaildw -u user1 -p
+
+Enter user1 as password
+```
+
+## Note: This program depends on the docker host being at address 172.17.0.1
+

--- a/open-ended-capstone/RetailDW/__main__.py
+++ b/open-ended-capstone/RetailDW/__main__.py
@@ -1,6 +1,6 @@
 import sys
 
-from RetailDW.demo import demo1
+from RetailDW.demo import demo1, demo2
 
 
 def main():
@@ -9,7 +9,8 @@ def main():
     Usage: python -m RetailDW [demo name]
     """
     demos_available = {
-        "demo1": (demo1, "Initial and incremental load of source system")
+        "demo1": (demo1, "Initial and incremental load of source system"),
+        "demo2": (demo2, "Load of source system.  ETL to target system"),
     }
 
     if len(sys.argv) > 1:

--- a/open-ended-capstone/RetailDW/demo.py
+++ b/open-ended-capstone/RetailDW/demo.py
@@ -1,8 +1,23 @@
+from datetime import datetime
+from time import sleep
+
 import psycopg2
 from psycopg2.extensions import connection
 
-from RetailDW.etlutils import create_table, incremental_load
-from RetailDW.product import PRODUCT_TABLE, PRODUCT_CREATE_SQL_PG
+import mysql.connector
+from mysql.connector import connect
+
+from RetailDW.etlutils import (
+    create_table,
+    load_source_table,
+    extract_table_to_target,
+    ETL_HISTORY_CREATE_MYSQL,
+)
+from RetailDW.product import (
+    PRODUCT_TABLE,
+    PRODUCT_CREATE_SQL_PG,
+    PRODUCT_CREATE_SQL_MYSQL,
+)
 
 
 def demo1() -> None:
@@ -12,7 +27,7 @@ def demo1() -> None:
     inserts and 50 updates.
     """
     source_connection: connection = psycopg2.connect(
-        "dbname=postgres host=172.17.0.1 user=postgres password=postgres"
+        "dbname=retaildw host=172.17.0.1 user=user1 password=user1"
     )
 
     total_inserts = 0
@@ -20,14 +35,14 @@ def demo1() -> None:
 
     create_table(source_connection, PRODUCT_CREATE_SQL_PG)
 
-    inserted, updated = incremental_load(
+    inserted, updated = load_source_table(
         source_connection, PRODUCT_TABLE, n_inserts=5000, n_updates=0
     )
     total_inserts += inserted
     total_updates += updated
 
     for _ in range(5):
-        inserted, updated = incremental_load(
+        inserted, updated = load_source_table(
             source_connection, PRODUCT_TABLE, n_inserts=200, n_updates=50
         )
         total_inserts += inserted
@@ -36,3 +51,88 @@ def demo1() -> None:
     print(f"{total_inserts} inserts and {total_updates} updates processed.")
 
     source_connection.close()
+
+
+def demo2() -> None:
+    """Load Product records to source system and extract to target system. 
+
+    Create the product table and load 5000 rows to the source system.  Then run a loop of 5 incremental loads, each
+    having 200 inserts and 50 updates. After each incremental load, extract records from the source system to the 
+    target system. The extract only reads data updated since the prior extract.
+    
+    Insert and update counts are printed after each operation.
+    """
+    source_connection: connection = psycopg2.connect(
+        dbname="retaildw", host="172.17.0.1", user="user1", password="user1"
+    )
+    target_connection: connection = connect(
+        host="172.17.0.1",
+        user="user1",
+        password="user1",
+        database="retaildw",
+        charset="utf8",
+    )
+
+    total_inserts_source = 0
+    total_updates_source = 0
+    total_inserts_target = 0
+    total_updates_target = 0
+
+    timestamp = datetime.now()
+
+    create_table(source_connection, PRODUCT_CREATE_SQL_PG)
+    create_table(target_connection, PRODUCT_CREATE_SQL_MYSQL)
+    create_table(target_connection, ETL_HISTORY_CREATE_MYSQL)
+
+    inserted, updated = load_source_table(
+        source_connection,
+        PRODUCT_TABLE,
+        n_inserts=5000,
+        n_updates=0,
+        timestamp=timestamp,
+    )
+
+    print(f"{inserted} inserts and {updated} updates processed at source: {timestamp}.")
+
+    total_inserts_source += inserted
+    total_updates_source += updated
+
+    for _ in range(5):
+
+        sleep(3)
+        timestamp = datetime.now()
+        inserted, updated = load_source_table(
+            source_connection,
+            PRODUCT_TABLE,
+            n_inserts=200,
+            n_updates=50,
+            timestamp=timestamp,
+        )
+
+        print(
+            f"{inserted} inserts and {updated} updates processed at source: {timestamp}."
+        )
+
+        total_inserts_source += inserted
+        total_updates_source += updated
+
+        inserted, updated, from_time, to_time = extract_table_to_target(
+            source_connection, target_connection, PRODUCT_TABLE
+        )
+
+        print(
+            f"{inserted} inserts and {updated} updates processed at target: From: {from_time} To: {to_time} "
+        )
+
+        total_inserts_target += inserted
+        total_updates_target += updated
+
+    print(
+        f"{total_inserts_source} inserts and {total_updates_source} updates processed at source."
+    )
+    print(
+        f"{total_inserts_target} inserts and {total_updates_target} updates processed at target."
+    )
+
+    source_connection.close()
+    target_connection.close()

--- a/open-ended-capstone/RetailDW/product.py
+++ b/open-ended-capstone/RetailDW/product.py
@@ -14,6 +14,27 @@ product_dimension_height FLOAT(11) NULL DEFAULT NULL,
 product_introduced_date DATE NULL DEFAULT NULL,
 product_discontinued BOOLEAN NULL DEFAULT FALSE,
 product_no_longer_offered BOOLEAN NULL DEFAULT FALSE,
+product_inserted_at TIMESTAMP NOT NULL,
+product_updated_at TIMESTAMP NOT NULL,
+PRIMARY KEY (product_id));
+"""
+
+PRODUCT_CREATE_SQL_MYSQL = """
+CREATE TABLE IF NOT EXISTS product (
+product_id INT NOT NULL,
+product_name VARCHAR(80) NOT NULL,
+product_description VARCHAR(255) NULL DEFAULT NULL,
+product_category VARCHAR(80) NULL DEFAULT NULL,
+product_brand VARCHAR(80) NULL DEFAULT NULL,
+product_preferred_supplier_id INT NULL DEFAULT NULL,
+product_dimension_length DOUBLE NULL DEFAULT NULL,
+product_dimension_width DOUBLE NULL DEFAULT NULL,
+product_dimension_height DOUBLE NULL DEFAULT NULL,
+product_introduced_date DATE NULL DEFAULT NULL,
+product_discontinued tinyint(1) NULL DEFAULT FALSE,
+product_no_longer_offered tinyint(1) NULL DEFAULT FALSE,
+product_inserted_at TIMESTAMP(6) NOT NULL,
+product_updated_at TIMESTAMP(6) NOT NULL,
 PRIMARY KEY (product_id));
 """
 
@@ -31,4 +52,6 @@ PRODUCT_TABLE = Table(
     Column("product_introduced_date", "DATE"),
     Column("product_discontinued", "BOOLEAN"),
     Column("product_no_longer_offered", "BOOLEAN"),
+    Column("product_inserted_at", "TIMESTAMP", isInsertedAt=True),
+    Column("product_updated_at", "TIMESTAMP", isUpdatedAt=True),
 )

--- a/open-ended-capstone/RetailDW/sqltypes.py
+++ b/open-ended-capstone/RetailDW/sqltypes.py
@@ -5,11 +5,20 @@ from typing import List
 class Column:
     """Database Column metadata"""
 
-    def __init__(self, column_name: str, column_type: str, isPrimaryKey: bool = False):
+    def __init__(
+        self,
+        column_name: str,
+        column_type: str,
+        isPrimaryKey: bool = False,
+        isInsertedAt: bool = False,
+        isUpdatedAt: bool = False,
+    ):
 
         self._name = column_name
         self._type = column_type
         self._isPrimaryKey = isPrimaryKey
+        self._isInsertedAt = isInsertedAt
+        self._isUpdatedAt = isUpdatedAt
 
     def get_name(self) -> str:
 
@@ -22,6 +31,14 @@ class Column:
     def isPrimaryKey(self) -> bool:
 
         return self._isPrimaryKey
+
+    def isInsertedAt(self) -> bool:
+
+        return self._isInsertedAt
+
+    def isUpdatedAt(self) -> bool:
+
+        return self._isUpdatedAt
 
 
 class Table:
@@ -37,9 +54,16 @@ class Table:
         self._name = name
         self._columns = [col for col in columns]
         primary_keys = [col.get_name() for col in columns if col.isPrimaryKey()]
-        if len(primary_keys) != 1:
-            raise Exception("Simulator requires exactly one primary key")
+        inserted_ats = [col.get_name() for col in columns if col.isInsertedAt()]
+        updated_ats = [col.get_name() for col in columns if col.isUpdatedAt()]
+        if (len(primary_keys), len(inserted_ats), len(updated_ats)) != (1, 1, 1):
+            raise Exception(
+                "Simulator requires exactly one primary key, inserted_at and updated_at column"
+            )
         self._primary_key = primary_keys[0]
+        self._inserted_at = inserted_ats[0]
+        self._updated_at = updated_ats[0]
+
         self._update_columns = [
             col for col in columns if col.get_type() == "VARCHAR"
         ]  # restrict to VARCHAR update
@@ -58,6 +82,10 @@ class Table:
     def get_primary_key(self) -> str:
 
         return self._primary_key
+
+    def get_updated_at(self) -> str:
+
+        return self._updated_at
 
     def get_column_names(self) -> List[str]:
         """ Return a complete list of Column names for the table."""

--- a/open-ended-capstone/docker-compose.yaml
+++ b/open-ended-capstone/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: "2"
+services:
+  postgres:
+    image: postgres
+    ports:
+      - "5432:5432"
+    environment: 
+      - POSTGRES_USER=user1
+      - POSTGRES_PASSWORD=user1
+      - POSTGRES_DB=retaildw
+  mysql:
+    image: mysql:8.0.23
+    ports:
+      - "3306:3306"
+    environment: 
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_USER=user1
+      - MYSQL_PASSWORD=user1
+      - MYSQL_DATABASE=retaildw


### PR DESCRIPTION
Please review demo2.  This is fully dockerized as per README.md.   I couldn't figure out how to give my docker gateway ip localhost or another DNS name, so the 172.17.0.1 continues to be hard-coded.

New functionality:

- Postgres and MySQL images are launched via docker-compose up.  Both databases are initialize with dbname=retaildw and a dbuser/dbpass user1/user1.

- _inserted_at/_created_at columns added to product table

- two principal functions 
    -  load_source_table  - add inserts and updates to Postgres source system
    - extract_table_to_target - pull records from source system more recent than last update bulk upsert to target system with mySQL REPLACE.

- Added etl_history table on target system to track history and preserve latest update time between runs

demo2 is an initial load of 5000 records followed by a 5 iterations of

  sleep(3)
  update 50 existing, add 200 new to source
  extract source to target


